### PR TITLE
Fix README to show the correct namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Simple testing library for ClojureScript, mirroring `clojure.test` as much as po
 
 ```clojure
 (ns mytest-ns
-  (:use-macros [cljs-test.macros :only [deftest is= is]]))
+  (:use-macros [cljs-test.macros :only [deftest is= is]])
+  (:require cljs-test.core))
   
 (deftest simple-case
   (is= 1 (+ 0 1))


### PR DESCRIPTION
Right now it suggests doing a `(:use-macros [cljs-test.core...`, but the macros are actually in the `cljs-test.macros` namespace. 
